### PR TITLE
fix: is_noun check should check for "m." or "f."

### DIFF
--- a/pyrae/core.py
+++ b/pyrae/core.py
@@ -408,7 +408,7 @@ class Definition(FromHTML):
         """ Gets a value indicating whether the category of the definition corresponds to a noun.
         """
         # noinspection SpellCheckingInspection
-        return self._category.abbr in ('s.', 'sust.')
+        return self._category.abbr in ('s.', 'sust.', 'm.', 'f.')
 
     @property
     def is_pronoun(self) -> bool:


### PR DESCRIPTION
En la RAE los sustantivos van directamente indicados por "m." y "f." (sustantivo masculino y femenino respectivamente).