### PR TITLE
feat: Add pickle support to search results

### DIFF
--- a/pyrae/core.py
+++ b/pyrae/core.py
@@ -20,6 +20,12 @@ class FromHTML(ABC):
         self._soup: Optional[BeautifulSoup] = None
         self.html = html
 
+    def __getstate__(self):
+        return self.html
+
+    def __setstate__(self, html):
+        self.__init__(html)
+
     @property
     def html(self) -> str:
         """ Gets the HTML text used for parsing.


### PR DESCRIPTION
Currently not all search result objects can be pickled, due to cyclical BeatuifulSoup trees. By converting to and from HTML, all objects can be pickled and unpickled correctly.