### PR TITLE
fix: Add combined abbreviation to is_noun check

### DIFF
--- a/pyrae/core.py
+++ b/pyrae/core.py
@@ -452,7 +452,7 @@ class Definition(FromHTML):
         """ Gets a value indicating whether the category of the definition corresponds to a noun.
         """
         # noinspection SpellCheckingInspection
-        return self._category.abbr in ('s.', 'sust.', 'm.', 'f.')
+        return self._category.abbr in ('s.', 'sust.', 'm.', 'f.', 'm. y f.')
 
     @property
     def is_pronoun(self) -> bool:


### PR DESCRIPTION
Looks like I missed one more option in #3... When the noun can be both masculino and femenino the abbreviation is "m. y f.".

Example: [percusionista](https://dle.rae.es/percusionista)