### PR TITLE
fix: Extract article's raw text before extracting soup's elements

### DIFF
--- a/pyrae/core.py
+++ b/pyrae/core.py
@@ -771,7 +771,6 @@ class Entry(FromHTML):
                 self._definitions.append(Definition(html=str(tag)))
         if not self._lema:
             raise Exception('Could not process lema from the given HTML.')
-        self._raw_text = self._soup.get_text()
 
     def _reset(self):
         """ Resets fields to a clean state. Needed when resetting the HTML text.
@@ -1111,6 +1110,7 @@ class Article(Entry):
         self._reset()
         if not self._soup.article or not self._soup.article.header:
             raise Exception('Invalid HTML.')
+        self._raw_text = self._soup.get_text()
         if self._soup.article.has_attr('id'):
             self._id = self._soup.article['id']
         lema_entry_tag = Tag(name='lema_entry')
@@ -1140,7 +1140,6 @@ class Article(Entry):
         self._process_entry(entry_tag=lema_entry_tag)
         for complex_form_tag in complex_forms_tags:
             self._complex_forms.append(Entry(html=str(complex_form_tag)))
-        self._raw_text = self._soup.get_text()
         self._parsed = True
 
     def _reset(self):


### PR DESCRIPTION
I saw that `Article` instances' `raw_text` seemed to be empty:

```python
from pyrae import dle

search_result = dle.search_by_word("selección")
print(repr(search_result.articles[0]))
```
```none
Article(id="XUE4F1v", lema="selección", raw_text="







")
```

I investigated a bit and it looks like the issue is that in `Article._parse_html`, the `raw_text` was extracted as the last step:
https://github.com/nachocho/pyrae/blob/4df5097e5769a9a47ddd4d3bff0120ccf0a1ad09/pyrae/core.py#L1116-L1143
but since each of the [`PageElement.append`](https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/bs4/element.py#L489) calls [results in a call to `PageElement.extract`](https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/bs4/element.py#L444), this means the appended element is actually removed from the `self._soup` object in-place, so by the end of processing, the soup is empty and `get_text()` returns just a bunch of whitespace.

So I moved the `get_text` call to the top of the function.